### PR TITLE
Potential fix for code scanning alert no. 2: Insecure randomness

### DIFF
--- a/src/sidepanel/store/helpers.ts
+++ b/src/sidepanel/store/helpers.ts
@@ -19,9 +19,23 @@ export const CHARS_PER_FRAME = 8;
 // ════════════════════════════════════════════════════════════════════
 
 export function createSessionId() {
-  return typeof crypto !== 'undefined' && 'randomUUID' in crypto
-    ? crypto.randomUUID()
-    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+
+  if (typeof crypto !== 'undefined' && 'getRandomValues' in crypto) {
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+
+    // UUID v4 formatting from CSPRNG bytes
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+    const hex = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  }
+
+  throw new Error('Secure random generator is unavailable for session id creation.');
 }
 
 export function createDefaultRecord<T>(defaultValue: T): Record<ProviderId, T> {


### PR DESCRIPTION
Potential fix for [https://github.com/null-object-0000/ai-clash/security/code-scanning/2](https://github.com/null-object-0000/ai-clash/security/code-scanning/2)

Use only cryptographically secure ID generation in `createSessionId()` and remove the `Math.random()` fallback.

Best fix (without changing behavior intent): in `src/sidepanel/store/helpers.ts`, keep `crypto.randomUUID()` as first choice, and for environments without it, generate 16 random bytes via `crypto.getRandomValues()` and format as a UUID-like string. As a final hard-fail (if `crypto` itself is unavailable), throw an error instead of silently using insecure randomness. This preserves the function’s purpose (unique session IDs) while eliminating weak randomness.

Changes needed:
- Edit `createSessionId()` in `src/sidepanel/store/helpers.ts`.
- No changes required in `src/sidepanel/store/index.ts`.
- No new imports or dependencies required (uses global Web Crypto API).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
