### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-docs-to-oss.yml
+++ b/.github/workflows/deploy-docs-to-oss.yml
@@ -8,6 +8,9 @@ name: Deploy Docs to OSS (VitePress)
 # OSS_REGION: OSS 区域（可选，默认为 us-east-1）
 # OSS_PATH: OSS 存储路径（可选，如：docs/）
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/null-object-0000/ai-clash/security/code-scanning/1](https://github.com/null-object-0000/ai-clash/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/deploy-docs-to-oss.yml` at workflow root (recommended here since there is only one job). Use the minimal required scope:

- `contents: read`

This preserves current functionality (`actions/checkout` works with read access) while preventing unnecessary token write privileges. No imports, methods, or dependencies are needed; this is a YAML configuration-only change near the top of the file (after `name`, before `on`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
