### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/packages/inject/src/standalone/entry.ts
+++ b/packages/inject/src/standalone/entry.ts
@@ -70,31 +70,19 @@ async function init() {
 // ============================================================================
 
 function detectProviderFromDomain(): string | null {
-  const hostname = location.hostname;
+  const hostname = location.hostname.toLowerCase();
 
-  if (hostname.includes('chat.deepseek.com')) {
-    return 'deepseek';
-  }
-  if (hostname.includes('doubao.com')) {
-    return 'doubao';
-  }
-  if (hostname.includes('www.qianwen.com')) {
-    return 'qianwen';
-  }
-  if (hostname.includes('tiangong.cn')) {
-    return 'longcat';
-  }
-  if (hostname.includes('yuanbao.tencent.com')) {
-    return 'yuanbao';
-  }
-  if (hostname.includes('yiyan.baidu.com')) {
-    return 'wenxin';
-  }
-  if (hostname.includes('aistudio.xiaomimimo.com')) {
-    return 'xiaomi';
-  }
+  const providerByHost: Record<string, string> = {
+    'chat.deepseek.com': 'deepseek',
+    'doubao.com': 'doubao',
+    'www.qianwen.com': 'qianwen',
+    'tiangong.cn': 'longcat',
+    'yuanbao.tencent.com': 'yuanbao',
+    'yiyan.baidu.com': 'wenxin',
+    'aistudio.xiaomimimo.com': 'xiaomi',
+  };
 
-  return null;
+  return providerByHost[hostname] ?? null;
 }
 
 // ============================================================================


### PR DESCRIPTION
Potential fix for [https://github.com/null-object-0000/ai-clash/security/code-scanning/3](https://github.com/null-object-0000/ai-clash/security/code-scanning/3)

Use strict hostname validation against an explicit allowlist/map of expected hosts.  
Best fix here (without changing intended functionality): normalize `location.hostname` to lowercase, then do exact equality checks using a `Record<string, string>` map from hostname to provider. This preserves current behavior for the listed canonical hosts and removes substring-bypass risk.

**Edit location:** `packages/inject/src/standalone/entry.ts`, inside `detectProviderFromDomain()` (lines 72–97 in the snippet).  
**What to change:**
- Replace all `hostname.includes('...')` checks with a single exact-match lookup.
- Add lowercase normalization (`location.hostname.toLowerCase()`).
- Keep return type/signature unchanged.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
