### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete URL substring sanitization

### DIFF
--- a/src/sidepanel/components/GlobalSettingsModal.tsx
+++ b/src/sidepanel/components/GlobalSettingsModal.tsx
@@ -70,8 +70,15 @@ function getInstallChannel(): InstallChannel {
   if (runtimeId === 'ggngmgpjdklmkpoldbfahmeefpnfhhai') return 'chrome';
   if (runtimeId === 'khjmihaeihajagobgbdhlbjeobdpmfkm') return 'edge';
   const updateUrl = chrome.runtime?.getManifest?.().update_url || '';
-  if (updateUrl.includes('clients2.google.com')) return 'chrome';
-  if (updateUrl.includes('edge.microsoft.com')) return 'edge';
+  try {
+    const hostname = new URL(updateUrl).hostname.toLowerCase();
+    const isAllowedHost = (allowedHost: string) =>
+      hostname === allowedHost || hostname.endsWith(`.${allowedHost}`);
+    if (isAllowedHost('clients2.google.com')) return 'chrome';
+    if (isAllowedHost('edge.microsoft.com')) return 'edge';
+  } catch {
+    // Ignore invalid update_url and fall back to manual channel.
+  }
   return 'manual';
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/null-object-0000/ai-clash/security/code-scanning/9](https://github.com/null-object-0000/ai-clash/security/code-scanning/9)

Use URL parsing and hostname allowlisting instead of substring checks.  
Best fix here: in `src/sidepanel/components/GlobalSettingsModal.tsx`, update `getInstallChannel()` so `update_url` is parsed with `new URL(updateUrl)`, extract `hostname`, normalize to lowercase, and compare against explicit allowed host sets (exact host or proper subdomain boundary via `.endsWith('.allowed-host')`).

Concretely:
- Replace lines 73–74 substring checks with a `try/catch` URL parse block.
- Add small helper logic inside `getInstallChannel()` to safely match hostnames.
- Keep existing behavior fallback to `'manual'` when URL is absent/invalid.

No new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
